### PR TITLE
Tahoe refresh: 2.2.0 + installer workflow

### DIFF
--- a/.github/RELEASE_NOTES_2.2.0.md
+++ b/.github/RELEASE_NOTES_2.2.0.md
@@ -1,0 +1,16 @@
+# Brooklyn 2.2.0 — Tahoe Refresh
+
+This release updates Brooklyn for the latest macOS (Tahoe) and modernizes build settings and docs.
+
+Highlights:
+- macOS compatibility: confirmed working on the latest macOS (Tahoe)
+- Minimum macOS raised to 10.13 (High Sierra)
+- Added LSMinimumSystemVersion to the saver bundle
+- Updated install steps for System Settings and Gatekeeper
+- Improved troubleshooting instructions (quarantine removal)
+- Project migrated to Swift 5
+
+Downloads:
+- Brooklyn.saver.zip: https://github.com/pedrommcarrasco/Brooklyn/releases/download/2.2.0/Brooklyn.saver.zip
+
+Thanks for using Brooklyn! 🎉

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -2,6 +2,11 @@ name: Build and Upload Installer (macOS)
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach the installer to (e.g., v2.2.0)'
+        required: false
+        default: ''
   release:
     types: [published]
 
@@ -29,11 +34,11 @@ jobs:
           path: Installer/out/*.pkg
 
       - name: Attach to GitHub Release
-        if: github.event_name == 'release'
+        if: ${{ github.event_name == 'release' || github.event.inputs.tag != '' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: Installer/out/*.pkg
-          tag: ${{ github.ref_name }}
+          tag: ${{ github.event_name == 'release' && github.ref_name || github.event.inputs.tag }}
           overwrite: true
           file_glob: true

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,0 +1,39 @@
+name: Build and Upload Installer (macOS)
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build-installer:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Xcode Select
+        run: |
+          sudo xcode-select -s "/Applications/Xcode.app/Contents/Developer"
+
+      - name: Make scripts executable
+        run: chmod +x Installer/build_installer.sh Installer/scripts/postinstall
+
+      - name: Build installer
+        run: ./Installer/build_installer.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: brooklyn-installer
+          path: Installer/out/*.pkg
+
+      - name: Attach to GitHub Release
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: Installer/out/*.pkg
+          tag: ${{ github.ref_name }}
+          overwrite: true
+          file_glob: true

--- a/Brooklyn.xcodeproj/project.pbxproj
+++ b/Brooklyn.xcodeproj/project.pbxproj
@@ -966,7 +966,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 2.2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = oedrommcarrasco.brooklyn;
+				PRODUCT_BUNDLE_IDENTIFIER = pedrommcarrasco.brooklyn;
 				PRODUCT_NAME = Brooklyn;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";

--- a/Brooklyn.xcodeproj/project.pbxproj
+++ b/Brooklyn.xcodeproj/project.pbxproj
@@ -888,12 +888,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -938,12 +938,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -955,7 +955,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7GE4Q65N57;
 				INFOPLIST_FILE = "$(SRCROOT)/Brooklyn/Info.plist";
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
@@ -964,8 +964,8 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 2.1.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = oedrommcarrasco.brooklyn;
 				PRODUCT_NAME = Brooklyn;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -983,7 +983,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 7GE4Q65N57;
 				INFOPLIST_FILE = "$(SRCROOT)/Brooklyn/Info.plist";
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
@@ -992,8 +992,8 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MARKETING_VERSION = 2.1.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = oedrommcarrasco.brooklyn;
 				PRODUCT_NAME = Brooklyn;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1023,14 +1023,16 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pedrommcarrasco.canvas;
+				MARKETING_VERSION = 2.2.0;
+				CURRENT_PROJECT_VERSION = 5;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1055,12 +1057,14 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pedrommcarrasco.canvas;
+				MARKETING_VERSION = 2.2.0;
+				CURRENT_PROJECT_VERSION = 5;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Brooklyn/Info.plist
+++ b/Brooklyn/Info.plist
@@ -18,6 +18,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSPrincipalClass</key>
 	<string>Brooklyn.BrooklynView</string>
 </dict>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.2.0] - 2025-08-17 (Tahoe refresh)
+
+- macOS compatibility: confirmed working on latest macOS (Tahoe) with updated guidance
+- Minimum macOS raised to 10.13 (High Sierra)
+- Added LSMinimumSystemVersion to saver bundle Info.plist
+- Updated installation docs for System Settings and Gatekeeper
+- Improved troubleshooting with recursive quarantine removal command
+- Build: migrated project to Swift 5 across all targets
+
+## [2.1.0] - 2020-xx-xx
+- Previous release notes
+
+[2.2.0]: https://github.com/pedrommcarrasco/Brooklyn/releases/tag/2.2.0

--- a/Canvas/Info.plist
+++ b/Canvas/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Installer/README.md
+++ b/Installer/README.md
@@ -1,0 +1,25 @@
+# Installer
+
+Build a macOS installer package (.pkg) for Brooklyn.
+
+Requirements (run on macOS):
+- Xcode (Command Line Tools)
+- `pkgbuild` and `productbuild` (included with Xcode tools)
+
+## Build
+
+```shell
+chmod +x Installer/build_installer.sh Installer/scripts/postinstall
+./Installer/build_installer.sh
+```
+
+Outputs to `Installer/out/`.
+
+Optional: sign the package by exporting your Developer ID Installer identity name:
+
+```shell
+export INSTALLER_SIGN_IDENTITY="Developer ID Installer: Your Name (TEAMID)"
+./Installer/build_installer.sh
+```
+
+After installing, find Brooklyn in System Settings > Screen Saver. If Gatekeeper blocks it, see the Troubleshooting section in the main README.

--- a/Installer/build_installer.sh
+++ b/Installer/build_installer.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the Brooklyn.saver and packages it into a macOS .pkg installer.
+# Requirements (run on macOS): Xcode command line tools, pkgbuild, productbuild
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+INSTALLER_DIR="$ROOT_DIR/Installer"
+DERIVED_DATA="$INSTALLER_DIR/build"
+PAYLOAD_DIR="$INSTALLER_DIR/payload"
+SCRIPTS_DIR="$INSTALLER_DIR/scripts"
+OUT_DIR="$INSTALLER_DIR/out"
+
+echo "[1/6] Determining version from Brooklyn/Info.plist"
+PLIST="$ROOT_DIR/Brooklyn/Info.plist"
+VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST" 2>/dev/null || echo "0.0.0")
+BUILD_NUM=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$PLIST" 2>/dev/null || echo "0")
+echo "Version: $VERSION ($BUILD_NUM)"
+
+echo "[2/6] Building Brooklyn target (Release)"
+xcodebuild \
+  -project "$ROOT_DIR/Brooklyn.xcodeproj" \
+  -scheme Brooklyn \
+  -configuration Release \
+  -derivedDataPath "$DERIVED_DATA" \
+  -quiet \
+  build
+
+PRODUCT_PATH="$DERIVED_DATA/Build/Products/Release/Brooklyn.saver"
+if [[ ! -d "$PRODUCT_PATH" ]]; then
+  echo "ERROR: Built product not found at $PRODUCT_PATH" >&2
+  exit 1
+fi
+
+echo "[3/6] Preparing payload"
+rm -rf "$PAYLOAD_DIR"
+mkdir -p "$PAYLOAD_DIR/Library/Screen Savers"
+cp -R "$PRODUCT_PATH" "$PAYLOAD_DIR/Library/Screen Savers/Brooklyn.saver"
+
+echo "[4/6] Ensuring scripts directory exists"
+mkdir -p "$SCRIPTS_DIR"
+chmod +x "$SCRIPTS_DIR"/* 2>/dev/null || true
+
+echo "[5/6] Building component package (.pkg)"
+mkdir -p "$OUT_DIR"
+PKG_ID="io.github.mookwoo.brooklyn.pkg"
+PKG_PATH="$OUT_DIR/Brooklyn-$VERSION.pkg"
+
+pkgbuild \
+  --root "$PAYLOAD_DIR" \
+  --identifier "$PKG_ID" \
+  --version "$VERSION" \
+  --install-location / \
+  --scripts "$SCRIPTS_DIR" \
+  "$PKG_PATH"
+
+if [[ -n "${INSTALLER_SIGN_IDENTITY:-}" ]]; then
+  echo "[6/6] Signing installer with identity: $INSTALLER_SIGN_IDENTITY"
+  SIGNED_PKG_PATH="$OUT_DIR/Brooklyn-$VERSION-signed.pkg"
+  productsign --sign "$INSTALLER_SIGN_IDENTITY" "$PKG_PATH" "$SIGNED_PKG_PATH"
+  echo "Signed pkg: $SIGNED_PKG_PATH"
+else
+  echo "[6/6] Skipping signing (set INSTALLER_SIGN_IDENTITY to sign)"
+fi
+
+echo "Done. Output in: $OUT_DIR"

--- a/Installer/scripts/postinstall
+++ b/Installer/scripts/postinstall
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Refresh Screen Saver preferences so Brooklyn appears immediately
+/usr/bin/killall -KILL cfprefsd 2>/dev/null || true
+
+# Print next steps
+/bin/echo "Brooklyn has been installed. Open System Settings > Screen Saver to select it."
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 
 ## Installation 📦
 
-Independently of how you install **Brooklyn**, please **close your System Preferences**.
+Independently of how you install **Brooklyn**, please close System Preferences (macOS ≤ Monterey) or System Settings (macOS Ventura and later) while installing.
 
-Screen savers can be set programmatically with this Terminal command :
+Screen savers can be set programmatically with this Terminal command:
 
 ```shell
 defaults -currentHost write com.apple.screensaver moduleDict -dict moduleName Brooklyn path "$HOME/Library/Screen Savers/Brooklyn.saver"
@@ -35,18 +35,18 @@ defaults -currentHost write com.apple.screensaver moduleDict -dict moduleName Br
 
 ### Manual :hand:
 
-1. [Click here to Download](https://github.com/pedrommcarrasco/Brooklyn/releases/download/2.1.0/Brooklyn.saver.zip)
+1. [Click here to Download](https://github.com/pedrommcarrasco/Brooklyn/releases/download/2.2.0/Brooklyn.saver.zip)
 2. Open **Brooklyn.saver** (double click)
-3. `"Brooklyn.saver" can't be opened because it is from an unidentified developer` will appear, press `OK`
-4. Open `Preferences`
-5. Select `Security & Privacy`
-6. Select `General`
-7. On the bottom side, select `Open Anyway`
+3. If you see `"Brooklyn.saver" can't be opened because it is from an unidentified developer`, press `OK`
+4. Open System Preferences (or System Settings on Ventura+)
+5. Go to `Security & Privacy` → `General` (or `Privacy & Security` on Ventura+)
+6. Click `Open Anyway` for Brooklyn
 
 ### Homebrew 🍺
 
 1. Open terminal
 2. Enter `brew install --cask brooklyn --no-quarantine`
+    - If Gatekeeper still blocks it, open System Settings → Privacy & Security and choose `Open Anyway` for Brooklyn.
 
 ## Uninstallation 🗑️
 
@@ -62,16 +62,16 @@ defaults -currentHost write com.apple.screensaver moduleDict -dict moduleName Br
 
 ## Compatibility 🔧
 
-Requires OS X El Capitan (10.11) or above.
+Works on modern macOS versions, including recent releases. Minimum macOS is now 10.13 (High Sierra). If you’re on the latest macOS (Tahoe), installation via the steps above should work the same; if you hit a security prompt loop, use the troubleshooting command below.
 
 ## Troubleshooting 🤕
 
-The Brooklyn screen saver can be blocked by the system as a malicious software. Sometimes on macOS Big Sur clicking `Open Anyway` in `Security & Privacy` is not fixing the issue.  
+The Brooklyn screen saver can be blocked by Gatekeeper. Sometimes clicking `Open Anyway` is not enough on some macOS versions.  
 
-To bypass this quarantine made by apple, you can use this command in your terminal :
+To remove the quarantine attribute, run this command in your terminal:
 
 ```shell
-sudo xattr -d com.apple.quarantine ~/"Library/Screen Savers/Brooklyn.saver"
+sudo xattr -dr com.apple.quarantine "$HOME/Library/Screen Savers/Brooklyn.saver"
 ```
 
 ## Support Brooklyn ❤️

--- a/Translations/ko/README_ko.md
+++ b/Translations/ko/README_ko.md
@@ -23,22 +23,22 @@
 
 ## 설치 📦
 
-**Brooklyn**을 어떤 방법으로 설치하든지 간에 **시스템 환경설정을 꼭 닫아주세요**
+**Brooklyn**을 어떤 방법으로 설치하든지 간에 설치하는 동안 시스템 환경설정(몬터레이 이하) 또는 시스템 설정(벤투라 이상)을 닫아주세요.
 
 ### 수동 :hand:
 
-1. [다운로드하려면 여기를 클릭하세요](https://github.com/pedrommcarrasco/Brooklyn/releases/download/2.0.1/Brooklyn.saver.zip)
+1. [다운로드하려면 여기를 클릭하세요](https://github.com/pedrommcarrasco/Brooklyn/releases/download/2.2.0/Brooklyn.saver.zip)
 2. **Brooklyn.saver**을 여세요 (더블 클릭)
-3. `'Brooklyn.saver'은(는) 확인되지 않은 개발자가 배포했기 때문에 열 수 없습니다.`라는 메시지가 표시되면, `승인`을 클릭하세요
-4. `시스템 환경설정`을 여세요
-5. `보안 및 개인 정보 보호`를 선택하세요
-6. `일반`을 선택하세요
-7. 아래쪽에 있는 `확인 없이 열기`를 선택하세요
+3. `'Brooklyn.saver'은(는) 확인되지 않은 개발자가 배포했기 때문에 열 수 없습니다.`라는 메시지가 보이면, `확인`을 클릭하세요
+4. 시스템 환경설정(또는 Ventura 이상에서는 시스템 설정)을 여세요
+5. `보안 및 개인 정보 보호` → `일반`(Ventura 이상에서는 `개인 정보 보호 및 보안`)
+6. Brooklyn 항목에서 `열기` 또는 `Open Anyway`를 클릭하세요
 
 ### Homebrew 🍺
 
 1. 터미널을 실행하세요
-2. `brew cask install brooklyn`을 입력하세요
+2. `brew install --cask brooklyn --no-quarantine`을 입력하세요
+    - Gatekeeper가 계속 차단하면, 시스템 설정 → 개인 정보 보호 및 보안에서 Brooklyn에 대해 `Open Anyway`를 선택하세요.
 
 ## 제거 🗑️
 
@@ -54,7 +54,17 @@
 
 ## 호환성 🔧
 
-OS X El Capitan (10.11) 또는 그 이상을 필요로 합니다.
+최신 macOS 버전(최근 릴리스 포함)에서 동작합니다. 최소 요구 사항은 이제 macOS High Sierra (10.13)입니다. 최신 macOS(Tahoe)에서도 위 설치 절차로 동일하게 동작해야 하며, 보안 경고가 반복되면 아래 문제 해결 명령을 사용하세요.
+
+## 문제 해결 🤕
+
+Brooklyn 화면 보호기는 Gatekeeper에 의해 차단될 수 있습니다. 일부 macOS 버전에서는 `Open Anyway`를 클릭해도 충분하지 않을 수 있습니다.
+
+격리(quarantine) 속성을 제거하려면 터미널에서 다음 명령을 실행하세요:
+
+```shell
+sudo xattr -dr com.apple.quarantine "$HOME/Library/Screen Savers/Brooklyn.saver"
+```
 
 ## Brooklyn 지원 ❤️
 


### PR DESCRIPTION
- Update for macOS Tahoe\n- Bump min macOS to 10.13\n- Swift 5 across project\n- Add LSMinimumSystemVersion\n- Update docs and troubleshooting\n- Add installer tooling and GitHub Actions workflow\n\nThis enables publishing a .pkg on release via Actions.