### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,4 +1,6 @@
 name: Build and Upload Installer (macOS)
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/mookwoo/Brooklyn/security/code-scanning/1](https://github.com/mookwoo/Brooklyn/security/code-scanning/1)

To resolve the issue, add an explicit `permissions` block to the workflow. This can be set at the top (workflow-level) or per job. As a minimal starting point, set `contents: read`. However, the step "Attach to GitHub Release" uses `svenstaro/upload-release-action@v2`, which uploads files to a release, and this action requires `contents: write`. So, the workflow requires at least `contents: write` for the release attachment, but only `contents: read` to run everything else safely. It is clearest and safest to set the minimal required permissions at the workflow level, or if you expect to further restrict at job-level, you may set tighter permissions per job.

**Recommendation:**  
- Add `permissions:` at the top of the workflow (after `name`), with a minimal set:  
  - `contents: write` (to allow attaching to releases)  
- If finer granularity is needed and other jobs exist (not in this shown snippet), configure only the jobs requiring `write` permissions with the higher value, leaving all others as `read`.

For this snippet (with only one job that requires release permissions), add:
```yaml
permissions:
  contents: write
```
below the `name` key at the top.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
