### PR TITLE
updated for swift 6

### DIFF
--- a/Brooklyn.xcodeproj/project.pbxproj
+++ b/Brooklyn.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -578,8 +578,9 @@
 		21F2221D1B73B5AC00B9A11A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1620;
 				ORGANIZATIONNAME = "Pedro Carrasco";
 				TargetAttributes = {
 					21F222251B73B5AC00B9A11A = {
@@ -594,13 +595,11 @@
 			};
 			buildConfigurationList = 21F222201B73B5AC00B9A11A /* Build configuration list for PBXProject "Brooklyn" */;
 			compatibilityVersion = "Xcode 10.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
-				fr,
 			);
 			mainGroup = 21F2221C1B73B5AC00B9A11A;
 			productRefGroup = 21F222271B73B5AC00B9A11A /* Products */;
@@ -870,9 +869,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -927,9 +928,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -950,12 +953,12 @@
 		21F222321B73B5AC00B9A11A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 4;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 7GE4Q65N57;
 				INFOPLIST_FILE = "$(SRCROOT)/Brooklyn/Info.plist";
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
@@ -964,7 +967,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = oedrommcarrasco.brooklyn;
 				PRODUCT_NAME = Brooklyn;
@@ -978,12 +981,12 @@
 		21F222331B73B5AC00B9A11A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 4;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 7GE4Q65N57;
 				INFOPLIST_FILE = "$(SRCROOT)/Brooklyn/Info.plist";
 				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
@@ -992,7 +995,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = oedrommcarrasco.brooklyn;
 				PRODUCT_NAME = Brooklyn;
@@ -1017,13 +1020,14 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Canvas/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pedrommcarrasco.canvas;
@@ -1049,13 +1053,14 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Canvas/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pedrommcarrasco.canvas;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Brooklyn.xcodeproj/xcshareddata/xcschemes/Brooklyn.xcscheme
+++ b/Brooklyn.xcodeproj/xcshareddata/xcschemes/Brooklyn.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Brooklyn.xcodeproj/xcshareddata/xcschemes/Canvas.xcscheme
+++ b/Brooklyn.xcodeproj/xcshareddata/xcschemes/Canvas.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Brooklyn/Contexts/BrooklynManager.swift
+++ b/Brooklyn/Contexts/BrooklynManager.swift
@@ -23,9 +23,9 @@ final class BrooklynManager {
     let player: LoopPlayer
     
     // MARK: Private Set Properties
-    private (set) var selectedAnimations: [Animation]
-    private (set) var numberOfLoops: Int
-    private (set) var hasRandomOrder: Bool
+    private(set) var selectedAnimations: [Animation]
+    private(set) var numberOfLoops: Int
+    private(set) var hasRandomOrder: Bool
     
     // MARK: Init
     init(mode: DisplayMode) {

--- a/Brooklyn/Info.plist
+++ b/Brooklyn/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Canvas/Info.plist
+++ b/Canvas/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string></string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
@@ -30,12 +32,10 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>CFBundleDisplayName</key>
-	<string></string>
-	<key>SUFeedURL</key>
-	<string>https://raw.githubusercontent.com/pedrommcarrasco/Brooklyn/master/appcast.xml</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/pedrommcarrasco/Brooklyn/master/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>MTH0QlQzAxEaw5hHy+653O4Nwg5buZ9GP72dOr6J+os</string>
 </dict>


### PR DESCRIPTION
This pull request updates project configuration and build settings to align with newer Xcode versions and macOS deployment targets, improves build performance, and ensures better compatibility and code hygiene. The changes primarily affect the Xcode project file and related configuration files.

**Project configuration and build settings:**

* Updated `objectVersion` and `LastUpgradeVersion` in `Brooklyn.xcodeproj/project.pbxproj` and `.xcscheme` files to reflect Xcode 16 upgrade, ensuring compatibility with the latest Xcode features. [[1]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfL6-R6) [[2]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfR581-R583) [[3]](diffhunk://#diff-34aa576019502860b3b4ae4a154d56dafeb4cccffe66991db8d99475d94f716aL3-R3) [[4]](diffhunk://#diff-11489b94f6247fdf66c064390ffb41174e3bd9edee175ee492586b273e05705bL3-R3)
* Changed `MACOSX_DEPLOYMENT_TARGET` from `10.11` to `11.5` across all targets to require a newer minimum macOS version. [[1]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfL967-R970) [[2]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfL995-R998) [[3]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfR1023-R1030) [[4]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfR1056-R1063)
* Enabled parallel building of independent targets for faster builds (`BuildIndependentTargetsInParallel = YES`).
* Added `DEAD_CODE_STRIPPING = YES` and `ENABLE_USER_SCRIPT_SANDBOXING = YES` to build settings for both Debug and Release configurations, improving security and binary size. [[1]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfR872-R876) [[2]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfR931-R935) [[3]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfL953-R961) [[4]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfL981-R989) [[5]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfR1023-R1030) [[6]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfR1056-R1063)

**Localization and Info.plist improvements:**

* Standardized development region configuration by setting `CFBundleDevelopmentRegion` to use the `$(DEVELOPMENT_LANGUAGE)` variable in both `Brooklyn/Info.plist` and `Canvas/Info.plist`, and cleaned up known regions in the project file. [[1]](diffhunk://#diff-4dcb9942a7580bd2179480fc5c3f1ba0f3d093e3e9ff5c6c35ba8acef31bd3cfL597-L603) [[2]](diffhunk://#diff-1719bda364ad10c321cda6e9d7fe50da1131ea84d5978f666179d846e875b606L6-R6) [[3]](diffhunk://#diff-95c57abef39c9d19abbed571732dd03db850369a5113ef7ef884d94520ba9e28R7-R8)
* Fixed the placement of `CFBundleDisplayName` and `SUFeedURL` in `Canvas/Info.plist` for proper structure and clarity.## What was done?
* Added ...
* Fixed ...
* Updated ...
* ...

## Why?
This was mainly done because ...

## Screenshots
If there's any relevant screenshot please attach it here.
